### PR TITLE
apply resources serially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+* Apply resources serially to avoid TLS timeout
+
 ## [1.8.6] - 2018-05-29
 ### Added
 * Key value pairs as yargs for apply function

--- a/commands/apply.js
+++ b/commands/apply.js
@@ -1,8 +1,8 @@
 /* Copyright (c) 2018 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-const { loadEnvironment, logApplies } = require('./lib')
-const { loadResources, kubectl } = require('../')
+const { applyResources, loadEnvironment, logApplies } = require('./lib')
+const { loadResources } = require('../')
 
 async function execute (options) {
   const environment = loadEnvironment(options.env)
@@ -20,14 +20,6 @@ async function execute (options) {
 
   const applies = await applyResources(resources, { env: options.env })
   logApplies(applies)
-}
-
-function applyResources (resources, options) {
-  return Promise.all(
-    resources.map(r => {
-      return kubectl.apply(r, options)
-    })
-  )
 }
 
 module.exports = execute

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -2,7 +2,7 @@
  * Apache-2.0 */
 
 const { loadEnvironment, logApplies, kubecfg } = require('./lib')
-const { loadResources, kubectl } = require('../')
+const { applyResources, loadResources, kubectl } = require('../')
 
 async function execute (options) {
   // options has certificate-authority-data, cluster, env, tag, user (oidc user)
@@ -40,14 +40,6 @@ async function execute (options) {
   await Promise.all(
     deployments.map(d => {
       return kubectl.rollout(d, 'status', { namespace: options.env })
-    })
-  )
-}
-
-function applyResources (resources, options) {
-  return Promise.all(
-    resources.map(r => {
-      return kubectl.apply(r, options)
     })
   )
 }

--- a/commands/lib/apply-resources.js
+++ b/commands/lib/apply-resources.js
@@ -1,0 +1,22 @@
+const { compact } = require('lodash')
+const kubectl = require('../../kubectl')
+
+module.exports = async function (resources, options) {
+  const operations = compact(
+    resources.map(resource => {
+      if (['PodDisruptionBudget', 'ConfigMap'].includes(resource.kind)) {
+        return {resource, args: { ...options, force: true }}
+      } else if (resource.kind === 'CronJob') {
+        return {resource, args: { ...options, validate: false }}
+      } else {
+        return {resource, args: options}
+      }
+    })
+  )
+  let results = []
+  for (const operation of operations) {
+    const {resource, args} = operation
+    results.push(await kubectl.apply(resource, args))
+  }
+  return results
+}

--- a/commands/lib/index.js
+++ b/commands/lib/index.js
@@ -2,6 +2,7 @@
  * Apache-2.0 */
 
 module.exports = {
+  applyResources: require('./apply-resources'),
   loadEnvironment: require('./load-environment'),
   logApplies: require('./log-applies'),
   kubecfg: require('./kubecfg')


### PR DESCRIPTION
When trying to apply commands locally I have been receiving TLS timeouts. This switches to serialapplies. It takes a bit longer but but has some advantages:
- easier to know exactly what failed
- can control concurrency in the future
- no tls timeouts